### PR TITLE
Add 2nd argument for the fetch() in loadAnnotations

### DIFF
--- a/src/highlighter/Highlighter.js
+++ b/src/highlighter/Highlighter.js
@@ -130,7 +130,7 @@ export default class Highlighter {
   }
 
   applyStyles = (annotation, spans) => {
-    const extraClasses = this.formatter ? this.formatter(annotation, spans) : '';
+    const extraClasses = this.formatter ? this.formatter(annotation) : '';
     spans.forEach(span => span.className = `r6o-annotation ${extraClasses}`.trim());
   }
 

--- a/src/highlighter/Highlighter.js
+++ b/src/highlighter/Highlighter.js
@@ -130,7 +130,7 @@ export default class Highlighter {
   }
 
   applyStyles = (annotation, spans) => {
-    const extraClasses = this.formatter ? this.formatter(annotation) : '';
+    const extraClasses = this.formatter ? this.formatter(annotation, spans) : '';
     spans.forEach(span => span.className = `r6o-annotation ${extraClasses}`.trim());
   }
 

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -107,7 +107,7 @@ export class Recogito {
   /**
    * Loads JSON-LD WebAnnotations from the given URL.
    */
-  loadAnnotations = url => fetch(url)
+  loadAnnotations = (url, requestArgs) => fetch(url, requestArgs)
     .then(response => response.json()).then(annotations => {
       this.setAnnotations(annotations);
       return annotations;


### PR DESCRIPTION
As proposed in https://github.com/recogito/recogito-js/issues/45, adds the possibility to add a 2nd argument for the fetch call in loadAnnotations. Can be used for example in adding JWT auth headers to the request.