### PR TITLE
Body nesting V2

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -54,12 +54,14 @@ export class Recogito {
     this._wrapperEl.style.position = 'relative';
 
     if (contentEl instanceof HTMLBodyElement) {
-      this._wrapperEl.append(...contentEl.childNodes);
-      contentEl.appendChild(this._wrapperEl);
-    } else {
-      contentEl.parentNode.insertBefore(this._wrapperEl, contentEl);
-      this._wrapperEl.appendChild(contentEl);
+      this._newContentEl = document.createElement('DIV')
+      this._newContentEl.append(...contentEl.childNodes);
+      contentEl.append(this._newContentEl);
+      contentEl = this._newContentEl;
     }
+    contentEl.parentNode.insertBefore(this._wrapperEl, contentEl);
+    this._wrapperEl.appendChild(contentEl);
+
 
 
     this._appContainerEl = document.createElement('DIV');


### PR DESCRIPTION
After testing in the wild the first version of was causing issues. This version will:
- if the contentEl is type body create a new div
- append all the body children into the new div
- append the new div to the body
- ressagin contentEl(body) to be the new div

