### PR TITLE
Allow style and data attributes in formatter (#57)

### DIFF
--- a/src/highlighter/Highlighter.js
+++ b/src/highlighter/Highlighter.js
@@ -156,7 +156,7 @@ export default class Highlighter {
         const { className, style } = format;
         if (className) extraClasses = className;
         if (style) spans.forEach(span => {
-          span.setAttribute('style', `${span.style} ${style}`.trim());
+          span.setAttribute('style', `${span.style.cssText} ${style}`.trim());
         });
       }
       // Copy data attributes


### PR DESCRIPTION
Hi @rsimon! Here's a PR to address the first two bullet points of https://github.com/recogito/recogito-js/issues/57.

Working with a client (eScriptorium) that uses recogito-js and needs colors pulled from an API endpoint dynamically applied to annotations, so we need to be able to pass the custom `style` attribute like in Annotorious.

The comments and some code were cribbed directly from Annotorious 😄 